### PR TITLE
Refine description of when CapturedMouseEvent events are dispatched

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,27 @@
         more scrutiny in which information may safely be exposed. At present, only information
         already available to the capturing application is exposed - the mouse coordinates.
       </p>
+      <p>
+        If a <a data-cite="screen-capture/#dfn-capture-session">capture-session</a>
+        has an associated {{CaptureController}} whose
+        <a data-cite="screen-capture/#dfn-source">`[[Source]]`</a> is not
+        <a data-cite="mediacapture-streams/#track-ended">ended</a> then events with type
+        <dfn>capturedmousechange</dfn>, which do not bubble, which are not cancelable and which use
+        the {{CapturedMouseEvent}} interface, MUST be regularly dispatched on this
+        {{CaptureController}} to indicate the position of the captured cursor within the [=display
+        surface=] associated with
+        <a data-cite="screen-capture/#dfn-source">`CaptureController.[[Source]]`</a>, or the
+        cursor's departure from that surface.
+      </p>
+      <p>
+        User agents MAY limit the frequency with which events are fired. This can be achieved by
+        briefly buffering events, then skipping the events for some states and reporting only the
+        latest one. User agents SHOULD only buffer for very short periods of time.
+      </p>
+      <p>
+        Events MUST NOT be fired after the original video track and all its clones have been
+        stopped.
+      </p>
       <pre class="idl">
         [Exposed=Window]
         interface CapturedMouseEvent : Event {
@@ -156,29 +177,20 @@
     </section>
     <section id="capture-controller-extensions">
       <h2>CaptureController Extensions</h2>
+      <p>
+        We extend {{CaptureController}} to enable developers to listen to {{CapturedMouseEvent}}
+        events dispatched during a
+        <a data-cite="screen-capture/#dfn-capture-session">capture-session</a>:
+      </p>
       <pre class="idl">
         partial interface CaptureController {
           attribute EventHandler oncapturedmousechange;
         };
       </pre>
       <dl data-link-for="CaptureController" data-dfn-for="CaptureController">
-        <dt>
-          <dfn>oncapturedmousechange</dfn>
-        </dt>
+        <dt><dfn>oncapturedmousechange</dfn> of type {{EventHandler}}</dt>
         <dd>
-          <p>
-            We extend {{CaptureController}} with {{CaptureController/oncapturedmousechange}}, an
-            {{EventHandler}} for events of type {{CapturedMouseEvent}}.
-          </p>
-          <p>
-            User agents MAY limit the frequency with which events are fired. This can be achieved by
-            briefly buffering events, then skipping the events for some states and reporting only
-            the latest one. User agents SHOULD only buffer for very short periods of time.
-          </p>
-          <p>
-            Events MUST NOT be fired after the original video track and all its clones have been
-            stopped.
-          </p>
+          <p>The event type of this event is {{capturedmousechange}}</p>
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
- Align the way oncapturedmousechange is specified with similar EventHandler attributes from the "Media Capture and Streams" spec (i.e. by referring to an event type).
- Elaborate in the CapturedMouseEvent section the way events are dispatched on CaptureController objects associated to a capture-session, defining a new capturedmousechange type for them. Also move there the requirements about when to fire the event.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mouse-events/pull/10.html" title="Last updated on Jul 6, 2023, 11:57 AM UTC (0ae6fe6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-mouse-events/10/6e64ef2...fred-wang:0ae6fe6.html" title="Last updated on Jul 6, 2023, 11:57 AM UTC (0ae6fe6)">Diff</a>