### PR TITLE
Add type and Event options to CapturedMouseEvent's constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!-- Ignore this change - I am just nudging PR-preview into action. -->
 <!DOCTYPE html>
 <html lang="en-us">
   <head>

--- a/index.html
+++ b/index.html
@@ -79,12 +79,23 @@
       <pre class="idl">
         [Exposed=Window]
         interface CapturedMouseEvent : Event {
-          constructor(optional CapturedMouseEventInit eventInitDict = {});
+          constructor(DOMString type, optional CapturedMouseEventInit eventInitDict = {});
           readonly attribute long surfaceX;
           readonly attribute long surfaceY;
         };
       </pre>
       <dl data-link-for="CapturedMouseEvent" data-dfn-for="CapturedMouseEvent">
+        <dt><dfn constructor>constructor()</dfn></dt>
+        <dd>
+          <p>Constructs a new {{CapturedMouseEvent}}.</p>
+          <p>The arguments are passed as-it to {{Event}}'s constructor.</p>
+          <p>If an {{CapturedMouseEventInit}} argument is provided then the
+            constructor <a data-cite="WEBIDL#dfn-throw">throws</a> a
+            <a data-cite="WEBIDL#exceptiondef-rangeerror">RangeError</a>
+            exception if any of {{CapturedMouseEventInit.surfaceX}} or
+            {{CapturedMouseEventInit.surfaceY}} is negative, and they are not
+            both equal to -1.
+        </dd>
         <dt><dfn attribute>surfaceX</dfn></dt>
         <dd>
           <p>
@@ -114,7 +125,7 @@
     <section id="captured-mouse-change-event-init">
       <h2>CapturedMouseEventInit dictionary</h2>
       <pre class="idl">
-        dictionary CapturedMouseEventInit {
+        dictionary CapturedMouseEventInit : EventInit {
           long surfaceX = -1;
           long surfaceY = -1;
         };

--- a/index.html
+++ b/index.html
@@ -88,13 +88,13 @@
         <dt><dfn constructor>constructor()</dfn></dt>
         <dd>
           <p>Constructs a new {{CapturedMouseEvent}}.</p>
-          <p>The arguments are passed as-it to {{Event}}'s constructor.</p>
-          <p>If an {{CapturedMouseEventInit}} argument is provided then the
-            constructor <a data-cite="WEBIDL#dfn-throw">throws</a> a
-            <a data-cite="WEBIDL#exceptiondef-rangeerror">RangeError</a>
-            exception if any of {{CapturedMouseEventInit.surfaceX}} or
+          <p>The arguments are passed as is to {{Event}}'s constructor.</p>
+          <p>If any of {{CapturedMouseEventInit.surfaceX}} or
             {{CapturedMouseEventInit.surfaceY}} is negative, and they are not
-            both equal to -1.
+            both equal to -1, then the constructor
+            <a data-cite="WEBIDL#dfn-throw">throws</a> a
+            <a data-cite="WEBIDL#exceptiondef-rangeerror">RangeError</a>
+            exception.
         </dd>
         <dt><dfn attribute>surfaceX</dfn></dt>
         <dd>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-<!-- Ignore this change - I am just nudging PR-preview into action. -->
 <!DOCTYPE html>
 <html lang="en-us">
   <head>


### PR DESCRIPTION
This commit tweaks the IDL to align CapturedMouseEvent's constructor with those of other Event-derived interfaces:
- Add a mandatory DOMString type argument.
- Make CapturedMouseEventInit derive from EventInit, so that bubbles/cancelable/composed options are accepted too.

These new values are passed as-it to the constructor of the parent interface but details are not explicitly stated. This is similar to how MediaStreamTrackEvent's constructor is specified in "Media Capture and Streams".

Closes issue #8


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/mouse-events/pull/11.html" title="Last updated on May 26, 2023, 2:35 PM UTC (7120977)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/mouse-events/11/b31a9e2...fred-wang:7120977.html" title="Last updated on May 26, 2023, 2:35 PM UTC (7120977)">Diff</a>