### PR TITLE
Linkify "fire an event" concept and use active tense

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,17 +83,17 @@
         If a <a data-cite="screen-capture/#dfn-capture-session">capture-session</a>
         has an associated {{CaptureController}} whose
         <a data-cite="screen-capture/#dfn-source">`[[Source]]`</a> is not
-        <a data-cite="mediacapture-streams/#track-ended">ended</a> then events with type
-        <dfn>capturedmousechange</dfn>, which do not bubble, which are not cancelable and which use
-        the {{CapturedMouseEvent}} interface, MUST be regularly dispatched on this
-        {{CaptureController}} to indicate the position of the captured cursor within the [=display
-        surface=] associated with
+        <a data-cite="mediacapture-streams/#track-ended">ended</a> then the user age MUST
+        regularly [=fire an event=] named <dfn>capturedmousechange</dfn> at the
+        {{CaptureController}} using {{CapturedMouseEvent}}, with its {{Event/bubbles}} and
+        {{Event/cancelable}} attributes set to `false`, to indicate the position of the captured
+        cursor within the [=display surface=] associated with
         <a data-cite="screen-capture/#dfn-source">`CaptureController.[[Source]]`</a>, or the
         cursor's departure from that surface.
       </p>
       <p>
-        The user agent MUST NOT fire an event if the event immediately preceding it had the same
-        values in all of its fields. (That is to say, two identical events will not be conseuctively
+        The user agent MUST NOT [=fire an event=] if the event immediately preceding it had the same
+        values in all of its fields. (That is to say, two identical events will not be consecutively
         fired.)
       </p>
       <p>


### PR DESCRIPTION
Paragraph that describes firing of `capturedmousechange` events used but did not link to the `fire an event` concept. Also, it used passive form, which is usually bad practice as it somewhat hides the subject of the action (here the user agent). Also, the spec crawler does not like passive sentences and failed to extract the event interface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/captured-mouse-events/pull/30.html" title="Last updated on Jul 12, 2023, 12:18 PM UTC (678dcd5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-mouse-events/30/6171745...tidoust:678dcd5.html" title="Last updated on Jul 12, 2023, 12:18 PM UTC (678dcd5)">Diff</a>